### PR TITLE
Improve calculation of maxFA

### DIFF
--- a/include/libkairos/calendar.h
+++ b/include/libkairos/calendar.h
@@ -17,10 +17,17 @@ public:
     // Function to calculate total workable hours in a month
     static double workableHours(int year, int month, double hoursPerDay, const Journal *journal = nullptr);
     static double workableHours(QDate &from, QDate &to, double hoursPerDay, const Journal *journal = nullptr);
-private:
+
     // Function to check if a given date is a holiday
     static bool isHoliday(const QDate &date, const Journal *journal = nullptr);
 
+    // Runtime-konfigurierbare Zusatzfeiertage
+    static void addCustomHoliday(const QDate &date);
+    static void removeCustomHoliday(const QDate &date);
+    static void clearCustomHolidays();
+
+private:
+    static QSet<QDate> s_customHolidays;
 };
 
 #endif // CALENDAR_H

--- a/include/libkairos/journal.h
+++ b/include/libkairos/journal.h
@@ -219,7 +219,8 @@ public:
     double getTargetTime() const;
 
     double getTimeValues(QString string) const;
-    double getMaxTelecommuteTime(const QDate &from, const QDate &to, const double factor, const double targetTime);
+    double getMaxTelecommuteTime(const QDate &from, const QDate &to, const double factor, const double targetTime) const;
+    double effectiveWorkableHours(const QDate &from, const QDate &to, double targetTime) const;
 private:
     mutable QVector<Workday> workdays; /**< List of workdays in the journal. */
     /**

--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -1,5 +1,41 @@
 #include "libkairos/calendar.h"
 
+QSet<QDate> Calendar::s_customHolidays;
+
+void Calendar::addCustomHoliday(const QDate &date)
+{
+    s_customHolidays.insert(date);
+}
+
+void Calendar::removeCustomHoliday(const QDate &date)
+{
+    s_customHolidays.remove(date);
+}
+
+void Calendar::clearCustomHolidays()
+{
+    s_customHolidays.clear();
+}
+
+QDate calculateEasterSunday(int year) {
+    // Computus algorithm to calculate the date of Easter Sunday
+    int a = year % 19;
+    int b = year / 100;
+    int c = year % 100;
+    int d = b / 4;
+    int e = b % 4;
+    int f = (b + 8) / 25;
+    int g = (b - f + 1) / 3;
+    int h = (19 * a + b - d - g + 15) % 30;
+    int i = c / 4;
+    int k = c % 4;
+    int l = (32 + 2 * e + 2 * i - h - k) % 7;
+    int m = (a + 11 * h + 22 * l) / 451;
+    int month = (h + l - 7 * m + 114) / 31;
+    int day = ((h + l - 7 * m + 114) % 31) + 1;
+    return QDate(year, month, day);
+}
+
 /* Calculate total workable hours in a month */
 double Calendar::workableHours(int year, int month,
                                double hoursPerDay, const Journal *journal) {
@@ -46,7 +82,7 @@ double Calendar::workableHours(QDate& from, QDate& to,
 bool Calendar::isHoliday(const QDate &date, const Journal *journal)
 {
     // 1. Fixed calendar holidays
-    const QList<QDate> holidays = {
+    QList<QDate> holidays = {
         QDate(date.year(), 1, 1),       // New Year's Day
         QDate(date.year(), 5, 1),       // Labour Day
         QDate(date.year(), 10, 3),      // Day of German Unity
@@ -54,11 +90,26 @@ bool Calendar::isHoliday(const QDate &date, const Journal *journal)
         QDate(date.year(), 12, 26),     // Second Christmas Day
     };
 
+    // Add movable holidays
+    QDate easterSunday = calculateEasterSunday(date.year());
+    holidays.append(easterSunday.addDays(-2)); // Good Friday
+    holidays.append(easterSunday.addDays(1));  // Easter Monday
+    holidays.append(easterSunday.addDays(39)); // Ascension Day
+    holidays.append(easterSunday.addDays(50)); // Whit Monday
+
     if (holidays.contains(date)) {
         return true;
     }
 
-    // 2. Optional: derive "holidays" from Journal (user specific)
+    // 2. Custom holidays, which Kairos will specify at runtime
+    for (const QDate &custom : s_customHolidays) {
+        if (custom.month() == date.month() &&
+            custom.day()  == date.day()) {
+            return true;
+        }
+    }
+
+    // 3. Optional: derive "holidays" from Journal (specific to user)
     if (!journal) {
         return false;
     }
@@ -74,8 +125,16 @@ bool Calendar::isHoliday(const QDate &date, const Journal *journal)
                 if (type == Invalid)
                     return false;
             }
-            if (tpShortCode != 101 && workday.getTargetTime() == QTime(0, 0))
-                return true;
+            /* Eigentlich gedacht um im JournalParser nicht erkannte Feiertage aufzufangen;
+             * allerdings führt dies dazu, dass tatsächlich statt gefundene Arbeitstage als
+             * Feiertag erkannt werden durch die folgende If-Abfrage
+             *
+             * FIXME: Mein Vorschlag ist, dass diese Abfrage hier nicht mehr gemacht wird,
+             * und dass Firmenschließtage und sonstige Arbeitsfreie Tage
+             * einfach unter CustomHolidays eingetragen werden
+             *
+             * if (tpShortCode != 101 && workday.getTargetTime() == QTime(0, 0))
+                return true;*/
         }
     }
 

--- a/src/journal.cpp
+++ b/src/journal.cpp
@@ -55,6 +55,64 @@ Workday& Journal::getWorkdayByDate(const QDate& date) {
     }
 }
 
+double Journal::effectiveWorkableHours(const QDate &from,
+                                       const QDate &to,
+                                       double targetTime) const
+{
+    if (to < from) {
+        return 0.0;
+    }
+
+    // 1. Zeitraum auf volle Monate erweitern:
+    //    - startOfRange = erster Tag des from-Monats
+    //    - endOfRange   = letzter Tag des to-Monats
+    QDate startOfRange(from.year(), from.month(), 1);
+    QDate endOfRange(to.year(), to.month(),
+                     QDate(to.year(), to.month(), 1).daysInMonth());
+
+    // 2. Basis: Sollstunden über alle vollen Monate summieren
+    double workable = 0.0;
+
+    int year  = startOfRange.year();
+    int month = startOfRange.month();
+
+    while (QDate(year, month, 1) <= QDate(endOfRange.year(), endOfRange.month(), 1)) {
+        workable += Calendar::workableHours(year, month, targetTime, this);
+
+        if (month == 12) {
+            month = 1;
+            ++year;
+        } else {
+            ++month;
+        }
+    }
+
+    // 3. Fehlzeiten im erweiterten Bereich genau einmal abziehen
+    QVector<Workday> days = getWorkdays(startOfRange, endOfRange);
+
+    for (const auto &workday : days) {
+        const QDate date = workday.getDate();
+
+        // Nur reguläre Arbeitstage berücksichtigen
+        if (date.dayOfWeek() == Qt::Saturday || date.dayOfWeek() == Qt::Sunday)
+            continue;
+        if (Calendar::isHoliday(date, this)) {
+            continue;
+        }
+
+        // Voller Abwesenheitstag
+        if (workday.getType() == AbsentType) {
+            workable -= targetTime;
+        }
+    }
+
+    if (workable < 0.0) {
+        workable = 0.0;
+    }
+
+    return workable;
+}
+
 /* Returns the total telecommute time in a specified time span (in hours) */
 double Journal::calculateTelecommutePeriod(const QDate& from, const QDate& to) {
     QVector<Workday> workdaysInTimespan = getWorkdays(from, to);
@@ -73,40 +131,18 @@ double Journal::remainingTelecommuteTime(const QDate& from, const QDate& to,
     return maxTelecommuteTime - calculateTelecommutePeriod(from, to);
 }
 
-double Journal::getMaxTelecommuteTime(const QDate& from, const QDate& to,
+double Journal::getMaxTelecommuteTime(const QDate &from,
+                                      const QDate &to,
                                       const double factor,
-                                      const double targetTime) {
-    // Basis: alle grundsätzlich möglichen Telearbeitsstunden im Monat
-    double maxTelecommuteTime =
-        Calendar::workableHours(from.year(), from.month(), targetTime, this) * factor;
-
-    // Relevante Workdays im gewünschten Zeitraum
-    QVector<Workday> workdaysInTimespan = getWorkdays(from, to);
-
-    for (const auto &workday : workdaysInTimespan) {
-        const QDate date = workday.getDate();
-
-        // Nur reguläre Werktage, die auch in workableHours enthalten sind
-        if (date.dayOfWeek() == Qt::Saturday || date.dayOfWeek() == Qt::Sunday)
-            continue;
-        if (Calendar::isHoliday(date, this))
-            continue;
-
-        // Wenn dieser Tag AbsentType ist, gibt es an diesem Tag 0 telecommute Kapazität
-        if (workday.getType() == WorkdayType::AbsentType) {
-            maxTelecommuteTime -= targetTime * factor;
-        }
-    }
-
-    if (maxTelecommuteTime < 0.0)
-        maxTelecommuteTime = 0.0;
-
-    return maxTelecommuteTime;
+                                      const double targetTime) const
+{
+    double effWorkable = effectiveWorkableHours(from, to, targetTime);
+    return effWorkable * factor;
 }
 
 /* Returns the percentage of spent telecommute time */
 double Journal::spentTelecommuteTime(const QDate& from, const QDate& to) {
-    double workableHours = Calendar::workableHours(from.year(), from.month(), 7.8, this);
+    double workableHours = Calendar::workableHours(from.year(), from.month(), this->getTargetTime(), this);
     return (calculateTelecommutePeriod(from, to) / workableHours);
 }
 

--- a/src/workday.cpp
+++ b/src/workday.cpp
@@ -106,6 +106,7 @@ WorkdayType Workday::getType() const
     for (const auto& segment : segments) {
 
         if (segment.getType() == TelecommuteWork ||
+            segment.getType() == AbsentFlexday ||
             segment.getType() == BusinessTrip ||
             segment.getType() == OfficeWork) {
             return WorkdayType::PresentType;


### PR DESCRIPTION
- Verändert die Berechnung der prognostizierten maximalen flexiblen Arbeit, indem sie von der effektiven Sollzeit abhängig gemacht wird
- Die effektive Sollzeit wird wie folgt berechnet: ES = SOLL - FZ, wobei FZ Urlaub- oder Krankheitstage sind, allerdings keine Gleittage oder Dienstreisen

In meinen Beispielen funktioniert die Berechnung jetzt, aber Du kannst gerne nochmal drüber schauen.